### PR TITLE
Check presence of list keys in subsequent entries in a list when parsing JSON input

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -1360,8 +1360,8 @@ attr_repeat:
                 new->prev = list;
                 list->next = new;
 
-                /* copy the validity and when flags */
-                new->validity = list->validity;
+                /* set the validity and when flags */
+                new->validity = ly_new_node_validity(list->schema);
                 new->when_status = list->when_status;
 
                 /* fix the "last" pointer */

--- a/tests/data/files/keys2.yang
+++ b/tests/data/files/keys2.yang
@@ -1,0 +1,15 @@
+module keys2 {
+  yang-version 1.1;
+  namespace "urn:test:keys2";
+  prefix keys2;
+
+  list l {
+    key "key1 key2";
+    leaf key1 {
+      type uint16;
+    }
+    leaf key2 {
+      type uint16;
+    }
+  }
+}

--- a/tests/data/test_keys.c
+++ b/tests/data/test_keys.c
@@ -140,6 +140,35 @@ test_keys_missing2(void **state)
 }
 
 static void
+test_keys_missing3(void **state)
+{
+    const char *schemafile = TESTS_DIR"/data/files/keys2.yang";
+    struct state *st = (*state);
+    const struct lys_module *mod;
+
+    static const char *data =
+    "{"
+        "\"keys2:l\": ["
+            "{"
+                "\"key1\": 11,"
+                "\"key2\": 12"
+            "},"
+            "{"
+                "\"key1\": 21"
+            "}"
+        "]"
+    "}";
+
+    /* load special schema for this test */
+    mod = lys_parse_path(st->ctx, schemafile, LYS_YANG);
+    assert_ptr_not_equal(mod, NULL);
+
+    /* validation should fail as the second entry in the list is missing key2 */ 
+    st->dt = lyd_parse_mem(st->ctx, data, LYD_JSON, LYD_OPT_CONFIG | LYD_OPT_STRICT);
+    assert_ptr_equal(st->dt, NULL);
+}
+
+static void
 test_keys_inorder(void **state)
 {
     struct state *st = (*state);
@@ -211,6 +240,7 @@ int main(void)
                     cmocka_unit_test_setup_teardown(test_keys_correct2, setup_f, teardown_f),
                     cmocka_unit_test_setup_teardown(test_keys_missing, setup_f, teardown_f),
                     cmocka_unit_test_setup_teardown(test_keys_missing2, setup_f, teardown_f),
+                    cmocka_unit_test_setup_teardown(test_keys_missing3, setup_f, teardown_f),
                     cmocka_unit_test_setup_teardown(test_keys_inorder, setup_f, teardown_f),
                     cmocka_unit_test_setup_teardown(test_keys_inorder2, setup_f, teardown_f), };
 


### PR DESCRIPTION
List's keys are mandatory in YANG. There is currently a bug where the presence of keys is only checked on the first entry in a list when parsing JSON input.

The key check happens in `lyv_data_content` at
https://github.com/metaswitch-ak10/libyang/blob/6884c02a010ddf6b7d98f9725a2c4e53ecfe9fdb/src/validation.c#L715-L717
, which is only called if the `LYD_VAL_MAND` flag is set for the node. 

This flag is cleared from a node after successful validation at 
https://github.com/metaswitch-ak10/libyang/blob/6884c02a010ddf6b7d98f9725a2c4e53ecfe9fdb/src/validation.c#L788-L789

When parsing JSON data, `lyv_data_content` is called iteratively on each entry in a list at 
https://github.com/metaswitch-ak10/libyang/blob/6884c02a010ddf6b7d98f9725a2c4e53ecfe9fdb/src/parser_json.c#L1351
When moving onto the next entry in the list, the validation flags are copied from the previous entry
https://github.com/metaswitch-ak10/libyang/blob/6884c02a010ddf6b7d98f9725a2c4e53ecfe9fdb/src/parser_json.c#L1363-L1364
, but at this point the `LYD_VAL_MAND` flag on the previous entry has been cleared, so the key check won't be performed on subsequent list entries.

To fix this, I have set the validation flags on a subsequent entry to their initial value.

I have also added a test which fails without this fix and made sure that the existing tests pass.

 